### PR TITLE
sk87: fix corner LED color order, add battery display and retail Fn c…

### DIFF
--- a/keyboards/womier/common/wireless/transport.c
+++ b/keyboards/womier/common/wireless/transport.c
@@ -21,7 +21,7 @@ void wls_transport_enable(bool enable) {
     if (enable) {
         if (host_get_driver() != &wireless_driver) {
             host_set_driver(&wireless_driver);
-            keyboard_protocol = true; // default with true
+            usb_device_state_set_protocol(USB_PROTOCOL_REPORT); // default with report protocol
         }
     } else {
         if (*md_getp_state() == MD_STATE_CONNECTED) {

--- a/keyboards/womier/sk87/config.h
+++ b/keyboards/womier/sk87/config.h
@@ -31,3 +31,7 @@
 
 #define RGB_MATRIX_FRAMEBUFFER_EFFECTS
 #define RGB_MATRIX_KEYPRESSES
+
+/* The RGB matrix driver is "custom" (see sk87.c), so the WS2812 driver is
+ * pulled in manually and needs its LED count defined explicitly. */
+#define WS2812_LED_COUNT RGB_MATRIX_LED_COUNT

--- a/keyboards/womier/sk87/keyboard.json
+++ b/keyboards/womier/sk87/keyboard.json
@@ -74,7 +74,7 @@
             "solid_reactive_simple": true,
             "typing_heatmap": true
         },
-        "driver": "ws2812",
+        "driver": "custom",
         "layout": [
             {"matrix": [0, 0], "x": 6, "y": 7, "flags": 4},
             {"matrix": [0, 1], "x": 21, "y": 7, "flags": 4},

--- a/keyboards/womier/sk87/keymaps/custom/keymap.c
+++ b/keyboards/womier/sk87/keymaps/custom/keymap.c
@@ -1,0 +1,140 @@
+// Copyright 2024 Wind (@yelishang)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+#ifdef WIRELESS_ENABLE
+#    include "wireless.h"
+#endif
+
+enum layers {
+    WIN_B,
+    WIN_FN,
+    MAC_B,
+    MAC_FN,
+};
+
+enum custom_keycodes {
+    KC_BATQ = QK_USER_0, // show battery level on the number row while held
+    KC_SBAR,             // toggle the side light bar / corner LEDs
+};
+
+typedef union {
+    uint32_t raw;
+    struct {
+        uint8_t sidebar_off : 1;
+    };
+} userconf_t;
+static userconf_t userconf;
+
+static bool bat_show = false;
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [WIN_B] = LAYOUT_ansi(
+		KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_F13,  KC_PSCR, KC_SCRL, KC_PAUS,
+		KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
+		KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,
+		KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,
+		KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT,          KC_UP,
+		KC_LCTL, KC_LGUI, KC_LALT, KC_LNG2,                   KC_SPC,                    KC_LNG1, KC_RALT,MO(WIN_FN),KC_APP,KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [WIN_FN] = LAYOUT_ansi(
+		EE_CLR,  KC_MYCM, KC_WHOM, KC_MAIL, KC_CALC, KC_MSEL, KC_MSTP, KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_VOLD, KC_VOLU, _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RGB_TOG, RGB_MOD, _______, _______,
+		DF(2),   KC_BT1,  KC_BT2,  KC_BT3,  KC_2G4,  KC_USB,  _______, RGB_SAD, RGB_SAI, _______, _______, _______, _______, _______, RGB_HUI, KC_SBAR, _______,
+		_______, _______, _______, _______, _______, _______, KC_SCRL, KC_PAUS, KC_HOME, KC_END,  _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,          RGB_VAI,
+		_______, GU_TOGG, _______, _______,                   KC_BATQ,                   _______, _______, _______, _______, _______, RGB_SPD, RGB_VAD, RGB_SPI
+    ),
+
+    [MAC_B] = LAYOUT_ansi(
+		KC_ESC,  KC_BRID, KC_BRIU, KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_VOLD, KC_VOLU, KC_F13,  KC_PSCR, KC_SCRL, KC_PAUS,
+		KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
+		KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,
+		KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,
+		KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT,          KC_UP,
+		KC_LCTL, KC_LALT, KC_LGUI, KC_LNG2,                   KC_SPC,                    KC_LNG1, KC_RGUI,MO(MAC_FN),KC_APP,KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [MAC_FN] = LAYOUT_ansi(
+		EE_CLR,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RGB_TOG, RGB_MOD, _______, _______,
+		DF(0),   KC_BT1,  KC_BT2,  KC_BT3,  KC_2G4,  KC_USB,  _______, RGB_SAD, RGB_SAI, _______, _______, _______, _______, _______, RGB_HUI, KC_SBAR, _______,
+		_______, _______, _______, _______, _______, _______, KC_SCRL, KC_PAUS, KC_HOME, KC_END,  _______, _______, _______, _______,
+		_______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,          RGB_VAI,
+		_______, _______, _______, _______,                   KC_BATQ,                   _______, _______, _______, _______, _______, RGB_SPD, RGB_VAD, RGB_SPI
+    )
+};
+// clang-format on
+
+void eeconfig_init_user(void) {
+    userconf.raw = 0;
+    eeconfig_update_user(userconf.raw);
+}
+
+void keyboard_post_init_user(void) {
+    userconf.raw = eeconfig_read_user();
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case KC_BATQ:
+            bat_show = record->event.pressed;
+#ifdef WIRELESS_ENABLE
+            if (record->event.pressed) {
+                md_inquire_bat(); // refresh the cached battery level
+            }
+#endif
+            return false;
+        case KC_SBAR:
+            if (record->event.pressed) {
+                userconf.sidebar_off ^= 1;
+                eeconfig_update_user(userconf.raw);
+            }
+            return false;
+        default:
+            return true;
+    }
+}
+
+// Number-row LED indices: the row-1 LEDs are chained right-to-left, so key
+// "1" ([1,1]) is LED 32 down to key "0" ([1,10]) at LED 23.
+static uint8_t digit_led_index(uint8_t digit) {
+    return 33 - digit;
+}
+
+bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+    if (userconf.sidebar_off) {
+        for (uint8_t i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
+            if (g_led_config.flags[i] & LED_FLAG_UNDERGLOW) {
+                rgb_matrix_set_color(i, 0x00, 0x00, 0x00);
+            }
+        }
+    }
+
+    if (bat_show) {
+        uint8_t bat = 100;
+#ifdef WIRELESS_ENABLE
+        bat = *md_getp_bat();
+#endif
+        uint8_t lit = (bat + 9) / 10; // 1 key per 10%
+        for (uint8_t d = 1; d <= 10; d++) {
+            uint8_t idx = digit_led_index(d);
+            if (d <= lit) {
+                if (bat <= 20) {
+                    rgb_matrix_set_color(idx, 0xFF, 0x00, 0x00);
+                } else if (bat <= 50) {
+                    rgb_matrix_set_color(idx, 0xFF, 0xA5, 0x00);
+                } else {
+                    rgb_matrix_set_color(idx, 0x00, 0xFF, 0x00);
+                }
+            } else {
+                rgb_matrix_set_color(idx, 0x00, 0x00, 0x00);
+            }
+        }
+    }
+
+    return true;
+}

--- a/keyboards/womier/sk87/keymaps/custom/rules.mk
+++ b/keyboards/womier/sk87/keymaps/custom/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/womier/sk87/rules.mk
+++ b/keyboards/womier/sk87/rules.mk
@@ -1,1 +1,6 @@
 include keyboards/womier/common/wireless/wireless.mk
+
+# RGB matrix uses a keyboard-level custom driver (see sk87.c) that wraps the
+# WS2812 driver: the 13 side-bar/corner LEDs are wired with a different chip
+# whose byte order has red and green swapped relative to the per-key LEDs.
+WS2812_DRIVER_REQUIRED := yes

--- a/keyboards/womier/sk87/sk87.c
+++ b/keyboards/womier/sk87/sk87.c
@@ -213,6 +213,37 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 
 #ifdef RGB_MATRIX_ENABLE
 
+#    include "ws2812.h"
+
+/* The side-bar/corner LEDs (LED_FLAG_UNDERGLOW, last 13 in the chain) use a
+ * different LED chip than the per-key LEDs: it latches red/green in the
+ * opposite order, so a plain WS2812 driver shows red as green on the corners.
+ * Swap the two channels for those LEDs only. */
+static void sk87_ws2812_init(void) {
+    ws2812_init();
+}
+
+static void sk87_ws2812_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
+    if (g_led_config.flags[index] & LED_FLAG_UNDERGLOW) {
+        ws2812_set_color(index, green, red, blue);
+    } else {
+        ws2812_set_color(index, red, green, blue);
+    }
+}
+
+static void sk87_ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
+    for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
+        sk87_ws2812_set_color(i, red, green, blue);
+    }
+}
+
+const rgb_matrix_driver_t rgb_matrix_driver = {
+    .init          = sk87_ws2812_init,
+    .flush         = ws2812_flush,
+    .set_color     = sk87_ws2812_set_color,
+    .set_color_all = sk87_ws2812_set_color_all,
+};
+
 #    ifdef WIRELESS_ENABLE
 bool wls_rgb_indicator_reset        = false;
 uint32_t wls_rgb_indicator_timer    = 0x00;


### PR DESCRIPTION
## Description

The 13 underglow/side-bar LEDs on the SK87 use an LED chip that latches
red/green in the opposite byte order to the per-key LEDs, so with the
plain WS2812 driver the corners never match the keys (solid red shows
green corners, cyan shows magenta, etc. — only blue looks right).

This PR replaces the rgb_matrix driver with a thin keyboard-level custom
driver (`sk87.c`) that wraps the WS2812 driver and swaps the R/G channels
only for LEDs flagged `LED_FLAG_UNDERGLOW`. Corners now match the per-key
color in every effect, including colors set over VIA.

It also fixes the build on the current branch head: `wireless/transport.c`
referenced the `keyboard_protocol` global that no longer exists in
quantum; replaced with `usb_device_state_set_protocol(USB_PROTOCOL_REPORT)`.
This affects every wireless board using `keyboards/womier/common/wireless`.

Finally, it adds a `custom` keymap that restores retail-firmware behavior
missing from the default keymap:

- `Fn+Space` — battery level shown on the number row (1 key per 10%,
  green / orange ≤50% / red ≤20%), queried from the wireless module
- `Fn+End` — side light bar on/off, persisted to EEPROM
- `Fn+H/J/K/L` — Scroll Lock / Pause / Home / End (as printed in the
  retail manual)
- VIA enabled

Tested on hardware (SK87, replacement PCB, wb32-dfu flash): corner colors
now track the keyboard color across all effects, battery display and
light-bar toggle work in wired and 2.4 GHz modes.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).